### PR TITLE
let user define sep for file path.

### DIFF
--- a/R/jsTree.R
+++ b/R/jsTree.R
@@ -83,7 +83,7 @@
 #' @import htmlwidgets
 #' @importFrom jsonlite toJSON
 #' @export
-jsTree <- function(obj, core=NULL, tooltips=NULL, nodestate=NULL, ... , width = NULL, height = NULL, elementId = NULL) {
+jsTree <- function(obj, core=NULL, tooltips=NULL, nodestate=NULL, ... , width = NULL, height = NULL, elementId = NULL, sep = '/') {
 
   preview.search <- NULL
   
@@ -101,7 +101,8 @@ jsTree <- function(obj, core=NULL, tooltips=NULL, nodestate=NULL, ... , width = 
                                          ),
                                   '.'),
                nodestate = nodestate,
-               tooltips  = tooltips
+               tooltips  = tooltips,
+               sep = sep
                )
   
   # forward options using x

--- a/R/jsTree.R
+++ b/R/jsTree.R
@@ -9,6 +9,7 @@
 #'   \code{'400px'}, \code{'auto'}) or a number, which will be coerced to a
 #'   string and have \code{'px'} appended.
 #' @param elementId The input slot that will be used to access the element.
+#' @param sep The separator for \code{'obj'} which indicates the hierarchy. Default to \code{'/'}.
 #' @details 
 #' 
 #' valid core objects can be found in the jsTree javascript library api

--- a/R/jsTree.R
+++ b/R/jsTree.R
@@ -9,7 +9,7 @@
 #'   \code{'400px'}, \code{'auto'}) or a number, which will be coerced to a
 #'   string and have \code{'px'} appended.
 #' @param elementId The input slot that will be used to access the element.
-#' @param sep The separator for \code{'obj'} which indicates the hierarchy. Default to \code{'/'}.
+#' @param sep character, separator for \code{'obj'} which defines the hierarchy, Default: \code{'/'}.
 #' @details 
 #' 
 #' valid core objects can be found in the jsTree javascript library api
@@ -84,7 +84,7 @@
 #' @import htmlwidgets
 #' @importFrom jsonlite toJSON
 #' @export
-jsTree <- function(obj, core=NULL, tooltips=NULL, nodestate=NULL, ... , width = NULL, height = NULL, elementId = NULL, sep = '/') {
+jsTree <- function(obj, sep = '/', core=NULL, tooltips=NULL, nodestate=NULL, ... , width = NULL, height = NULL, elementId = NULL) {
 
   preview.search <- NULL
   
@@ -108,7 +108,7 @@ jsTree <- function(obj, core=NULL, tooltips=NULL, nodestate=NULL, ... , width = 
   
   # forward options using x
   x <- list(core = jsonlite::toJSON(c(list(data=obj.in),core),auto_unbox = TRUE),
-            vcs = vcs)
+            vcs = vcs, sep=sep)
   
   if( 'preview.search'%in%names(match.call()) ) x$forcekey <- preview.search
   
@@ -120,6 +120,8 @@ jsTree <- function(obj, core=NULL, tooltips=NULL, nodestate=NULL, ... , width = 
   }
 
 
+  x$sep=sep
+  
   # create widget
   htmlwidgets::createWidget(
     name = 'jsTree',

--- a/R/jsTree.R
+++ b/R/jsTree.R
@@ -119,8 +119,6 @@ jsTree <- function(obj, sep = '/', core=NULL, tooltips=NULL, nodestate=NULL, ...
                  )
   }
 
-
-  x$sep=sep
   
   # create widget
   htmlwidgets::createWidget(

--- a/R/makelist.R
+++ b/R/makelist.R
@@ -52,10 +52,10 @@ makeList <- function(x,tooltips){
 }
 
 #' @importFrom data.table rbindlist
-nest <- function(l, root='root', nodestate=NULL, tooltips=NA){
+nest <- function(l, root='root', nodestate=NULL, tooltips=NA, sep='/'){
   
   df <- data.frame(V0=root,
-                   data.table::rbindlist(lapply(strsplit(l,'/'),
+                   data.table::rbindlist(lapply(strsplit(l,sep),
                                      function(x) as.data.frame(t(x),stringsAsFactors = FALSE)),
                                     fill=TRUE),
              stringsAsFactors = FALSE)

--- a/inst/htmlwidgets/jsTree.js
+++ b/inst/htmlwidgets/jsTree.js
@@ -115,7 +115,7 @@ HTMLWidgets.widget({
           //    nodes.push(data.instance.get_node(data.selected[i]).text);
           //}
           var node=$('.jstree' + el.id).jstree("get_selected", true);
-          var nodes=node.map(function(n){return $('.jstree' + el.id).jstree().get_path(n, '/')});
+          var nodes=node.map(function(n){return $('.jstree' + el.id).jstree().get_path(n, x.sep)});
         
           if(typeof(Shiny) !== "undefined"){
               Shiny.onInputChange(el.id + "_update",{

--- a/man/jsTree.Rd
+++ b/man/jsTree.Rd
@@ -5,7 +5,7 @@
 \title{Htmlwidget for the jsTree Javascript library}
 \usage{
 jsTree(obj, core = NULL, tooltips = NULL, nodestate = NULL, ...,
-  width = NULL, height = NULL, elementId = NULL)
+  width = NULL, height = NULL, elementId = NULL, sep = "/")
 }
 \arguments{
 \item{obj}{character, vector of directory tree}
@@ -23,6 +23,8 @@ jsTree(obj, core = NULL, tooltips = NULL, nodestate = NULL, ...,
 string and have \code{'px'} appended.}
 
 \item{elementId}{The input slot that will be used to access the element.}
+
+\item{sep}{The separator for \code{'obj'} which indicates the hierarchy. Default to \code{'/'}.}
 }
 \description{
 Htmlwidget for the jsTree Javascript library

--- a/man/jsTree.Rd
+++ b/man/jsTree.Rd
@@ -4,11 +4,13 @@
 \alias{jsTree}
 \title{Htmlwidget for the jsTree Javascript library}
 \usage{
-jsTree(obj, core = NULL, tooltips = NULL, nodestate = NULL, ...,
-  width = NULL, height = NULL, elementId = NULL, sep = "/")
+jsTree(obj, sep = "/", core = NULL, tooltips = NULL, nodestate = NULL,
+  ..., width = NULL, height = NULL, elementId = NULL)
 }
 \arguments{
 \item{obj}{character, vector of directory tree}
+
+\item{sep}{character, separator for \code{'obj'} which defines the hierarchy, Default: \code{'/'}.}
 
 \item{core}{list, additional parameters to pass to core of jsTree, default: NULL}
 
@@ -23,8 +25,6 @@ jsTree(obj, core = NULL, tooltips = NULL, nodestate = NULL, ...,
 string and have \code{'px'} appended.}
 
 \item{elementId}{The input slot that will be used to access the element.}
-
-\item{sep}{The separator for \code{'obj'} which indicates the hierarchy. Default to \code{'/'}.}
 }
 \description{
 Htmlwidget for the jsTree Javascript library


### PR DESCRIPTION
Thanks for the jsTree package. It is great.
I am using it to explore a hierarchical data structure, which are not file paths. 
Imagine in the shiny app you have to navigate through country / state / city.
And one of these names happen to have the forward slash `/`, which `jsTree` interprets to be the next level of the hierarchy. 

This PR let user define what the separator should be by supplying a `sep` argument.
